### PR TITLE
fix: Fix ECDSA certificate creation

### DIFF
--- a/ACME-PS/internal/classes/crypto/AcmePSKey.ps1
+++ b/ACME-PS/internal/classes/crypto/AcmePSKey.ps1
@@ -36,12 +36,16 @@ class AcmePSKey {
             $algo = [Security.Cryptography.RSA]::Create($keyParameters);
         }
         elseif($keySource.TypeName -iin @("ECDsa","ECDsaKeyExport")) {
+            $ecPoint = [System.Security.Cryptography.ECPoint]::new();
+            
+            $ecPoint.X = $keySource.X;
+            $ecPoint.Y = $keySource.Y;
+            
             $keyParameters = [System.Security.Cryptography.ECParameters]::new();
 
             $keyParameters.Curve = [AcmePSKey]::GetECDsaCurve($hashSize);
             $keyParameters.D = $keySource.D;
-            $keyParameters.Q.X = $keySource.X;
-            $keyParameters.Q.Y = $keySource.Y;
+            $keyParameters.Q = $ecPoint;
 
             $algo = [Security.Cryptography.ECDsa]::Create($keyParameters);
         }


### PR DESCRIPTION
This is a regression with the rewrite of they new way the keys are handled. For some reason you cannot init subproperties in PS like you do in .NET - so the X and Y values of Q never change. 